### PR TITLE
Modified both Some ja uutiset - and Kuvat ja videot - tabs' contents.

### DIFF
--- a/public/JSON/img.js
+++ b/public/JSON/img.js
@@ -1,0 +1,14 @@
+const images = [
+    {
+        url: "https://neckerman.com/wp-content/uploads/2015/03/house-fire.jpg",
+        name: "Tulipalo 1",
+        nameId: "tuli1"
+    },
+    {
+        url: "http://wrcb.images.worldnow.com/images/20415371_BG1.jpg",
+        name: "Tulipalo 2",
+        nameId: "tuli2"
+    }
+];
+
+export default images;

--- a/public/JSON/texts.js
+++ b/public/JSON/texts.js
@@ -1,0 +1,9 @@
+const texts = [
+    {
+        name: "Teksti 1",
+        nameId: "teksti1",
+        url: "http://cdn.ientry.com/sites/webpronews/article_pics/twitterlinebreaks421.png"
+    }
+];
+
+export default texts;

--- a/public/app.js
+++ b/public/app.js
@@ -10,6 +10,8 @@ import { BrowserRouter as Router, Route} from 'react-router-dom';
 import { getTehtavat } from './reducer/tehtavat/actions';
 import { getTabs } from './reducer/tabs/actions';
 import { getPages } from './reducer/pages/actions';
+import { getImages } from './reducer/images/actions';
+import { getTexts } from './reducer/texts/actions';
 
 //code from: https://scotch.io/courses/getting-started-with-react-and-redux/setting-up-the-redux-store
 const composeEnhancers = window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ || compose;
@@ -22,6 +24,8 @@ const container = document.querySelector('#app-container');
 store.dispatch(getTehtavat());
 store.dispatch(getTabs());
 store.dispatch(getPages());
+store.dispatch(getImages());
+store.dispatch(getTexts());
 
 ReactDOM.render(
     <Provider store={store}>

--- a/public/components/styles/styles.css
+++ b/public/components/styles/styles.css
@@ -9,6 +9,11 @@ h1, h2, p, ul, li {
     list-style-type: none;
 }
 
+img {
+    width: 50%;
+    height: 50%;
+}
+
 .content {
     background-color: whitesmoke;
     overflow: auto;
@@ -231,7 +236,7 @@ h1, h2, p, ul, li {
     grid-area: a;
     display: inline-block;
 }
-
+/*
 .some-grid {
     display: grid;
     grid-template-columns: 30% 50% 20%;
@@ -241,9 +246,21 @@ h1, h2, p, ul, li {
     background-color: white;
     height: 75vh;
     padding: 5px;
+}*/
+
+.some-grid {
+    display: grid;
+    grid-template-columns: 100%;
+    grid-template-rows: 50% 50%;
+    grid-template-areas: "b"
+                         "b";
+    background-color: white;
+    height: 75vh;
+    padding: 5px;
 }
 
-.somemenu {
+
+/*.somemenu {
     grid-area: a;
     display: grid;
     grid-template-rows: 25% 25% 25% 25%;
@@ -268,19 +285,20 @@ h1, h2, p, ul, li {
 .somemenu > a > .jaetut {
     grid-area: d;
     display: none;
-}
+}*/
 
 .somecontent {
     grid-area: b;
     display: inline-block;
 }
 
+/*
 .some-grid > .jaetut {
     grid-area: c;
     display: inline-block;
-}
+}*/
 
-.kuvatvideot-grid {
+/*.kuvatvideot-grid {
     display: grid;
     grid-template-columns: 40% 60%;
     grid-template-rows: 50% 50%;
@@ -289,9 +307,20 @@ h1, h2, p, ul, li {
     background-color: white;
     height: 75vh;
     padding: 5px;
+}*/
+
+.kuvatvideot-grid {
+    display: grid;
+    grid-template-columns: 100%;
+    grid-template-rows: 50% 50%;
+    grid-template-areas: "b"
+                         "b";
+    background-color: white;
+    height: 75vh;
+    padding: 5px;
 }
 
-.kuvatvideotmenu {
+/*.kuvatvideotmenu {
     grid-area: a;
     display: grid;
     grid-template-rows: 25% 25% 25% 25%;
@@ -315,7 +344,7 @@ h1, h2, p, ul, li {
 
 .kuvatvideotmenu > .kolmiulotteinen {
     grid-area: d;
-}
+}*/
 
 .kuvatvideotcontent {
     grid-area: b;

--- a/public/components/tehtPage/tabsComponents/kuvatvideot/KuvatComponents.js
+++ b/public/components/tehtPage/tabsComponents/kuvatvideot/KuvatComponents.js
@@ -1,21 +1,20 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { changeCurrentTemplate, setMenu } from '../../../../reducer/tab/actions';
+import { changeCurrentTemplate } from '../../../../reducer/tab/actions';
 
 const KuvatVideot = (props) =>
     <div className="kuvatvideot">
         {props.routes.map((comp) =>
-            <a onClick={props.selectItem(comp.nameId, 'GET_kuvatvideot', comp, props.routes)}>
-                <comp.component key={comp.nameId} {...comp}/>
+            <a onClick={props.selectItem(comp.nameId, 'GET_kuvatvideot', comp)}>
+                <comp.component key={comp.nameId} {...props}/>
             </a>
         )}
     </div>;
 
 const mapDispatchToProps = dispatch => ({
-    selectItem(id, type, content, components) {
+    selectItem(id, type, content) {
         return() => {
             dispatch(changeCurrentTemplate(id, type, content));
-            dispatch(setMenu(components));
         }
     }
 });

--- a/public/components/tehtPage/tabsComponents/modals/ModalContent.js
+++ b/public/components/tehtPage/tabsComponents/modals/ModalContent.js
@@ -5,7 +5,7 @@ import { hideModal } from '../../../../reducer/modal/actions';
 const ModalContent = (props) => (
     <div className={props.className}>
         <props.component/>
-        <button type="button" onClick={props.closeModal()}>
+        <button type="button" className="return-btn" onClick={props.closeModal()}>
             X
         </button>
     </div>

--- a/public/components/tehtPage/tabsComponents/reusables/templates/Component.js
+++ b/public/components/tehtPage/tabsComponents/reusables/templates/Component.js
@@ -1,0 +1,10 @@
+import React from 'react';
+
+const Component = (props) => (
+    <div className={props.className}>
+        <p>{props.title}</p>
+        <img src={props.src}/>
+    </div>
+);
+
+export default Component;

--- a/public/components/tehtPage/tabsComponents/someuutiset/SomeComponents.js
+++ b/public/components/tehtPage/tabsComponents/someuutiset/SomeComponents.js
@@ -1,21 +1,18 @@
 import React from 'react';
 import { connect } from 'react-redux';
-import { changeCurrentTemplate, setMenu } from '../../../../reducer/tab/actions';
+import { changeCurrentTemplate } from '../../../../reducer/tab/actions';
 
 const SomeComponents = (props) =>
     <div className="someuutiset">
         {props.routes.map((comp) =>
-            <a onClick={props.selectItem(comp.nameId, 'GET_some', comp, props.routes)}>
-                <comp.component key={comp.nameId} {...comp}/>
-            </a>
+            <comp.component key={comp.nameId} {...props}/>
         )}
     </div>;
 
 const mapDispatchToProps = dispatch => ({
-    selectItem(id, type, content, components) {
+    selectItem(id, type, content) {
         return () => {
             dispatch(changeCurrentTemplate(id, type, content));
-            dispatch(setMenu(components));
         }
     }
 });

--- a/public/components/tehtPage/tabsComponents/someuutiset/Tekstit.js
+++ b/public/components/tehtPage/tabsComponents/someuutiset/Tekstit.js
@@ -1,9 +1,19 @@
 import React from 'react';
+import Component from '../reusables/templates/Component';
+import { connect } from 'react-redux';
 
-const Tekstit = () =>
+const Tekstit = (props) =>
     <div className="tekstit">
         <p><b>Tekstit:</b></p>
-        <p>TESTI</p>
+        {props.texts.map((text) =>
+            <a onClick={props.selectItem(text.nameId, 'GET_teksti', text)}>
+                <Component src={text.url} className={text.nameId} title={text.name}/>
+            </a>
+        )}
     </div>;
 
-export default Tekstit;
+const mapStateToProps = ({ texts }) => ({
+    texts
+});
+
+export default connect(mapStateToProps, null)(Tekstit);

--- a/public/components/tehtPage/tabsComponents/someuutiset/kuvat.js
+++ b/public/components/tehtPage/tabsComponents/someuutiset/kuvat.js
@@ -1,9 +1,19 @@
 import React from 'react';
+import Component from '../reusables/templates/Component';
+import { connect } from 'react-redux';
 
-const Kuvat = () =>
+const Kuvat = (props) =>
     <div className="kuvat">
         <p><b>Kuvat:</b></p>
-        <p>TESTI</p>
+        {props.images.map((img) =>
+            <a onClick={props.selectItem(img.nameId, 'GET_kuva', img)}>
+                <Component src={img.url} className={img.nameId} title={img.name} key={img.nameId}/>
+            </a>
+        )}
     </div>;
 
-export default Kuvat;
+const mapStateToProps = ({ images }) => ({
+    images
+});
+
+export default connect(mapStateToProps)(Kuvat);

--- a/public/components/tehtPage/tabsComponents/templates/KuvatVideotTemplate.js
+++ b/public/components/tehtPage/tabsComponents/templates/KuvatVideotTemplate.js
@@ -4,7 +4,6 @@ import Menu from './Menu';
 
 const KuvatVideotTemplate = (props) => (
     <div className="kuvatvideot-grid">
-        <Menu className="kuvatvideotmenu" />
         <MainContent component={props.component} className="kuvatvideotcontent" {...props} />
     </div>
 );

--- a/public/components/tehtPage/tabsComponents/templates/MainContent.js
+++ b/public/components/tehtPage/tabsComponents/templates/MainContent.js
@@ -1,13 +1,14 @@
 import React from 'react';
 import { setOriginalTemplate } from '../../../../reducer/tab/actions';
 import { connect } from 'react-redux';
+import Component from '../reusables/templates/Component';
 
 const MainContent = (props) => (
     <div className={props.className}>
         <button type="button" className="return-btn" onClick={props.goBack()}>
             X
         </button>
-        <props.component/>
+        <Component src={props.url} className={props.nameId} title={props.name}/>
     </div>
 );
 

--- a/public/components/tehtPage/tabsComponents/templates/SomeUutisetTemplate.js
+++ b/public/components/tehtPage/tabsComponents/templates/SomeUutisetTemplate.js
@@ -1,13 +1,9 @@
 import React from 'react';
 import MainContent from './MainContent';
-import Menu from './Menu';
-import Jaetut from '../someuutiset/Jaetut';
 
 const SomeUutisetTemplate = (props) => (
     <div className="some-grid">
-        <Menu className="somemenu" />
         <MainContent component={props.component} className="somecontent" {...props} />
-        <Jaetut />
     </div>
 );
 

--- a/public/reducer/images/actions.js
+++ b/public/reducer/images/actions.js
@@ -1,0 +1,9 @@
+import images from '../../JSON/img';
+export const LOAD_IMAGES = 'LOAD_IMAGES';
+
+export function getImages() {
+    return {
+        type: LOAD_IMAGES,
+        images
+    }
+}

--- a/public/reducer/images/index.js
+++ b/public/reducer/images/index.js
@@ -1,0 +1,12 @@
+import { LOAD_IMAGES } from '../images/actions';
+
+const initialState = [];
+
+export default (state = initialState, action) => {
+    switch(action.type) {
+        case LOAD_IMAGES:
+            return action.images;
+        default:
+            return state;
+    }
+};

--- a/public/reducer/index.js
+++ b/public/reducer/index.js
@@ -6,6 +6,8 @@ import tab from './tab';
 import pages from './pages';
 import page from './page';
 import modal from './modal';
+import images from './images';
+import texts from './texts';
 
 //code from: https://scotch.io/courses/getting-started-with-react-and-redux/
 export default combineReducers({
@@ -15,5 +17,7 @@ export default combineReducers({
     tab,
     pages,
     page,
-    modal
+    modal,
+    images,
+    texts
 });

--- a/public/reducer/tab/actions.js
+++ b/public/reducer/tab/actions.js
@@ -10,6 +10,7 @@ export const RETURN_ORIGINAL_TEMPLATE = 'RETURN_ORIGINAL_TEMPLATE';
 export const SET_AS_MAIN_CONTENT = 'SET_AS_MAIN_CONTENT';
 export const SET_MENU = 'SET_MENU';
 
+
 export function setCurrentTab(id) {
     return {
         type: SET_CURRENT_TAB,

--- a/public/reducer/texts/actions.js
+++ b/public/reducer/texts/actions.js
@@ -1,0 +1,9 @@
+import texts from '../../JSON/texts';
+export const LOAD_TEXTS = 'LOAD_TEXTS';
+
+export function getTexts() {
+    return {
+        type: LOAD_TEXTS,
+        texts
+    }
+}

--- a/public/reducer/texts/index.js
+++ b/public/reducer/texts/index.js
@@ -1,0 +1,12 @@
+import { LOAD_TEXTS } from './actions';
+
+const initialState = [];
+
+export default (state = initialState, action) => {
+    switch(action.type) {
+        case LOAD_TEXTS:
+            return action.texts;
+        default:
+            return state;
+    }
+}


### PR DESCRIPTION
The content of the selected tab is now presented in more simple way; when the user clicks an item in a component, the template is changed and it looks like it is presented as a modal. Whether user chooses to close it or move to the other tab, the content's template is returned to the original one by those actions.